### PR TITLE
Correctly handle an unset seed length upper bound

### DIFF
--- a/ALeS.cpp
+++ b/ALeS.cpp
@@ -1474,7 +1474,7 @@ int main(int argc, char **argv)
 			verbose();
 			return 1;
 		}
-		if(upperBound >= N){
+		if(upperBound > N){
 			cerr<<"Invalid seed length upper bound !!!"<<endl;
 			cerr<<"length upper bound must be < region length !!!"<<endl;
 			//verbose();


### PR DESCRIPTION
Check that the upper bound is greater than, and not greater than or equal to, the length of the homology region.
Without this, setting the seed length upper bound is required because we assign the `upperBound` to the region length(`N)`.